### PR TITLE
Update to syn 2

### DIFF
--- a/katexit/Cargo.toml
+++ b/katexit/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/termoshtt/katexit"
 proc-macro = true
 
 [dependencies]
-quote = "1.0.9"
-proc-macro2 = "1.0.28"
-syn = { version = "1.0.75", features = ["full", "extra-traits"] }
+quote = "1.0.25"
+proc-macro2 = "1.0.60"
+syn = { version = "2.0.0", features = ["full", "extra-traits"] }

--- a/katexit/src/lib.rs
+++ b/katexit/src/lib.rs
@@ -42,7 +42,6 @@ fn katexit2(item: TokenStream2) -> TokenStream2 {
             | syn::Item::ForeignMod(syn::ItemForeignMod { ref mut attrs, .. })
             | syn::Item::Impl(syn::ItemImpl { ref mut attrs, .. })
             | syn::Item::Macro(syn::ItemMacro { ref mut attrs, .. })
-            | syn::Item::Macro2(syn::ItemMacro2 { ref mut attrs, .. })
             | syn::Item::Mod(syn::ItemMod { ref mut attrs, .. })
             | syn::Item::Static(syn::ItemStatic { ref mut attrs, .. })
             | syn::Item::Struct(syn::ItemStruct { ref mut attrs, .. })


### PR DESCRIPTION
This is the only crate left depending on syn 1 in our dependency tree; it'd be nice not to be building two copies of it.